### PR TITLE
Add aiortc dependency

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -5,10 +5,10 @@ description = "Backend for Manobela"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
+    "aiortc>=1.14.0",
     "fastapi[standard]>=0.128.0",
     "mediapipe>=0.10.31",
     "opencv-python>=4.12.0.88",
-    "aiortc>=1.8.0",
     "pydantic-extra-types>=2.11.0",
     "pydantic-settings>=2.12.0",
     "python-dotenv>=1.2.1",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -146,7 +146,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiortc", specifier = ">=1.8.0" },
+    { name = "aiortc", specifier = ">=1.14.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.128.0" },
     { name = "mediapipe", specifier = ">=0.10.31" },
     { name = "opencv-python", specifier = ">=4.12.0.88" },


### PR DESCRIPTION
### Changes

Added aiortc as a runtime dependency in pyproject.toml

Previously, aiortc had to be installed manually using uv pip install after uv sync. Declaring it in pyproject.toml makes dependency reproducible.

Had to input uv pip install many times thus here


