### PR TITLE
Add tabs to mobile app

### DIFF
--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -1,0 +1,61 @@
+import { Tabs } from 'expo-router';
+import { ChartScatter, NotepadText, Aperture, Bolt, HardDriveUpload } from 'lucide-react-native';
+import { ThemeToggle } from '@/components/theme-toggle';
+
+export default function TabLayout() {
+  return (
+    <Tabs
+      screenOptions={{
+        headerShown: true,
+        headerRight: () => <ThemeToggle />,
+
+        headerTitleStyle: {
+          marginLeft: 8,
+        },
+
+        headerRightContainerStyle: {
+          paddingRight: 12,
+        },
+      }}>
+      <Tabs.Screen
+        name="insights"
+        options={{
+          title: 'Insights',
+          tabBarIcon: ({ color, size }) => <ChartScatter color={color} size={size} />,
+        }}
+      />
+
+      <Tabs.Screen
+        name="guide"
+        options={{
+          title: 'Guide',
+          tabBarIcon: ({ color, size }) => <NotepadText color={color} size={size} />,
+        }}
+      />
+
+      <Tabs.Screen
+        name="index"
+        options={{
+          title: 'Monitor',
+          tabBarIcon: ({ color, size }) => <Aperture color={color} size={size} />,
+        }}
+      />
+
+      <Tabs.Screen
+        name="uploads"
+        options={{
+          title: 'Uploads',
+          tabBarIcon: ({ color, size }) => <HardDriveUpload color={color} size={size} />,
+        }}
+      />
+
+      <Tabs.Screen
+        name="settings"
+        options={{
+          title: 'Settings',
+          tabBarIcon: ({ color, size }) => <Bolt color={color} size={size} />,
+        }}
+      />
+    </Tabs>
+  );
+}

--- a/mobile/app/(tabs)/guide.tsx
+++ b/mobile/app/(tabs)/guide.tsx
@@ -1,0 +1,10 @@
+import { View } from 'react-native';
+import { Text } from '@/components/ui/text';
+
+export default function GuideScreen() {
+  return (
+    <View className="flex-1 items-center justify-center">
+      <Text className="text-lg font-bold">Guide</Text>
+    </View>
+  );
+}

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -1,23 +1,17 @@
 import { useCallback } from 'react';
-import { Stack } from 'expo-router';
 import { View, ScrollView } from 'react-native';
-import { ThemeToggle } from '@/components/theme-toggle';
 import { useCamera } from '@/hooks/useCamera';
 import { useMonitoringSession } from '@/hooks/useMonitoringSession';
 import { MediaStreamView } from '@/components/media-stream-view';
 import { ConnectionStatus } from '@/components/connection-status';
 import { MonitoringControls } from '@/components/monitoring-controls';
 import { InferenceDisplay } from '@/components/inference-display';
-
-const SCREEN_OPTIONS = {
-  title: 'Manobela',
-  headerRight: () => <ThemeToggle />,
-};
+import { Stack } from 'expo-router';
 
 const WS_BASE = process.env.EXPO_PUBLIC_WS_BASE!;
 const WS_URL = `${WS_BASE}/driver-monitoring`;
 
-export default function Screen() {
+export default function MonitorScreen() {
   const { localStream } = useCamera();
 
   const {
@@ -46,7 +40,7 @@ export default function Screen() {
 
   return (
     <ScrollView className="flex-1 px-4 py-4">
-      <Stack.Screen options={SCREEN_OPTIONS} />
+      <Stack.Screen options={{ title: 'Monitor' }} />
 
       <ConnectionStatus
         sessionState={sessionState}

--- a/mobile/app/(tabs)/insights.tsx
+++ b/mobile/app/(tabs)/insights.tsx
@@ -1,0 +1,10 @@
+import { View } from 'react-native';
+import { Text } from '@/components/ui/text';
+
+export default function InsightsScreen() {
+  return (
+    <View className="flex-1 items-center justify-center">
+      <Text className="text-lg font-bold">Insights</Text>
+    </View>
+  );
+}

--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -1,0 +1,10 @@
+import { View } from 'react-native';
+import { Text } from '@/components/ui/text';
+
+export default function SettingsScreen() {
+  return (
+    <View className="flex-1 items-center justify-center">
+      <Text className="text-lg font-bold">Settings</Text>
+    </View>
+  );
+}

--- a/mobile/app/(tabs)/uploads.tsx
+++ b/mobile/app/(tabs)/uploads.tsx
@@ -1,0 +1,10 @@
+import { View } from 'react-native';
+import { Text } from '@/components/ui/text';
+
+export default function UploadsScreen() {
+  return (
+    <View className="flex-1 items-center justify-center">
+      <Text className="text-lg font-bold">Uploads</Text>
+    </View>
+  );
+}

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -18,7 +18,9 @@ export default function RootLayout() {
   return (
     <ThemeProvider value={NAV_THEME[colorScheme ?? 'light']}>
       <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
-      <Stack />
+      <Stack>
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+      </Stack>
       <PortalHost />
     </ThemeProvider>
   );


### PR DESCRIPTION
## Describe your changes

Add tabs to mobile app with placeholder content:
- Insights
- Guide
- Monitor (index/main)
- Uploads
- Settings

Fixes #60
