### PR TITLE
Fix settings not refreshing

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -7,6 +7,7 @@ import { PortalHost } from '@rn-primitives/portal';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useColorScheme } from 'nativewind';
+import { SettingsProvider } from '@/hooks/useSettings';
 
 export {
   // Catch any errors thrown by the Layout component.
@@ -17,12 +18,14 @@ export default function RootLayout() {
   const { colorScheme } = useColorScheme();
 
   return (
-    <ThemeProvider value={NAV_THEME[colorScheme ?? 'light']}>
-      <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
-      <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-      </Stack>
-      <PortalHost />
-    </ThemeProvider>
+    <SettingsProvider>
+      <ThemeProvider value={NAV_THEME[colorScheme ?? 'light']}>
+        <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
+        <Stack>
+          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        </Stack>
+        <PortalHost />
+      </ThemeProvider>
+    </SettingsProvider>
   );
 }

--- a/mobile/hooks/useSettings.ts
+++ b/mobile/hooks/useSettings.ts
@@ -1,4 +1,13 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import {
+  createContext,
+  createElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import {
   defaultSettings,
   loadSettings,
@@ -6,7 +15,16 @@ import {
   type Settings,
 } from '../lib/settings';
 
-export const useSettings = () => {
+type SettingsContextValue = {
+  settings: Settings;
+  isLoading: boolean;
+  refreshSettings: () => Promise<void>;
+  saveSettings: (nextSettings: Settings) => Promise<void>;
+};
+
+const SettingsContext = createContext<SettingsContextValue | null>(null);
+
+const useSettingsState = (): SettingsContextValue => {
   const [settings, setSettings] = useState<Settings>(defaultSettings);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -55,4 +73,17 @@ export const useSettings = () => {
     refreshSettings,
     saveSettings,
   };
+};
+
+export const SettingsProvider = ({ children }: { children: ReactNode }) => {
+  const value = useSettingsState();
+  return createElement(SettingsContext.Provider, { value }, children);
+};
+
+export const useSettings = () => {
+  const context = useContext(SettingsContext);
+  if (!context) {
+    throw new Error('useSettings must be used within SettingsProvider');
+  }
+  return context;
 };


### PR DESCRIPTION
## Describe your changes

- Improved reconnection reliability by caching client IDs
- Fixed settings requiring app restart to take effect.

Fixes #82
