### PR TITLE
Fixed gaze metric warning when eyes are closed

### DIFF
--- a/backend/app/services/metrics/gaze.py
+++ b/backend/app/services/metrics/gaze.py
@@ -2,7 +2,9 @@ import logging
 
 from app.core.config import settings
 from app.services.metrics.base_metric import BaseMetric, MetricOutputBase
+from app.services.metrics.eye_closure import EyeClosureMetric
 from app.services.metrics.frame_context import FrameContext
+from app.services.metrics.utils.ear import average_ear
 from app.services.metrics.utils.eye_gaze_ratio import (
     left_eye_gaze_ratio,
     right_eye_gaze_ratio,
@@ -34,6 +36,10 @@ class GazeMetric(BaseMetric):
     DEFAULT_VERTICAL_RANGE = (0.35, 0.65)
     DEFAULT_MIN_SUSTAINED_SEC = 0.5
     DEFAULT_SMOOTHER_ALPHA = 0.4
+    DEFAULT_EYE_CLOSED_EAR_THRESHOLD = (
+        EyeClosureMetric.DEFAULT_EAR_THRESHOLD
+        * EyeClosureMetric.DEFAULT_EAR_HYSTERESIS_RATIO
+    )
 
     def __init__(
         self,
@@ -41,6 +47,7 @@ class GazeMetric(BaseMetric):
         vertical_range: tuple[float, float] = DEFAULT_VERTICAL_RANGE,
         min_sustained_sec: float = DEFAULT_MIN_SUSTAINED_SEC,
         smoother_alpha: float = DEFAULT_SMOOTHER_ALPHA,
+        eye_closed_ear_threshold: float = DEFAULT_EYE_CLOSED_EAR_THRESHOLD,
     ) -> None:
         """
         Args:
@@ -48,6 +55,7 @@ class GazeMetric(BaseMetric):
             vertical_range: Range of vertical gaze deviation (0-1, 0-1).
             min_sustained_sec: Minimum duration in seconds to count as gaze (0-inf).
             smoother_alpha: Smoother alpha for gaze smoothing (0-1).
+            eye_closed_ear_threshold: EAR threshold below which gaze alerts are suppressed (0-1).
         """
 
         # Validate inputs
@@ -61,9 +69,12 @@ class GazeMetric(BaseMetric):
             raise ValueError("vertical_range[1] must be between (0, 1).")
         if min_sustained_sec <= 0:
             raise ValueError("min_sustained_sec must be positive.")
+        if eye_closed_ear_threshold < 0 or eye_closed_ear_threshold > 1:
+            raise ValueError("eye_closed_ear_threshold must be between (0, 1).")
 
         self.horizontal_range = horizontal_range
         self.vertical_range = vertical_range
+        self.eye_closed_ear_threshold = eye_closed_ear_threshold
 
         fps = getattr(settings, "target_fps", 15)
         self.min_sustained_frames = max(1, int(min_sustained_sec * fps))
@@ -77,6 +88,10 @@ class GazeMetric(BaseMetric):
     def update(self, context: FrameContext) -> GazeMetricOutput:
         landmarks = context.face_landmarks
         if not landmarks:
+            return self._build_output()
+
+        if self._eyes_closed(landmarks):
+            self._reset_alert_state()
             return self._build_output()
 
         try:
@@ -99,7 +114,8 @@ class GazeMetric(BaseMetric):
             return self._build_output()
 
         if left_ratio is None and right_ratio is None:
-            gaze_on_road = False
+            self._reset_alert_state()
+            return self._build_output()
         else:
             left_on_h = in_range(
                 left_ratio[0] if left_ratio else None, self.horizontal_range
@@ -136,8 +152,7 @@ class GazeMetric(BaseMetric):
         return self._build_output()
 
     def reset(self) -> None:
-        self._sustained_out_of_range_frames = 0
-        self._gaze_alert_state = False
+        self._reset_alert_state()
         self.left_smoother.reset()
         self.right_smoother.reset()
 
@@ -146,6 +161,14 @@ class GazeMetric(BaseMetric):
             "gaze_alert": self._gaze_alert_state,
             "gaze_sustained": self._calc_sustained(),
         }
+
+    def _eyes_closed(self, landmarks) -> bool:
+        ear_value = average_ear(landmarks)
+        return ear_value <= self.eye_closed_ear_threshold
+
+    def _reset_alert_state(self) -> None:
+        self._sustained_out_of_range_frames = 0
+        self._gaze_alert_state = False
 
     def _calc_sustained(self) -> float:
         return min(self._sustained_out_of_range_frames / self.min_sustained_frames, 1.0)

--- a/mobile/components/metrics/metrics-display.tsx
+++ b/mobile/components/metrics/metrics-display.tsx
@@ -20,6 +20,7 @@ export const MetricsDisplay = ({ sessionState, metricsOutput }: MetricsDisplayPr
 
   // Stores whether the metrics display is disabled
   const isDisabled = sessionState !== 'active';
+  const eyeClosedSustained = metricsOutput?.eye_closure?.eye_closed_sustained ?? 0;
 
   /** Utility function to toggle the selected metric */
   const toggleMetric = useCallback((metricId: MetricId) => {
@@ -38,13 +39,14 @@ export const MetricsDisplay = ({ sessionState, metricsOutput }: MetricsDisplayPr
           const config = METRIC_DISPLAY_CONFIGS[metricId];
           // Get the metric data
           const metricData = metricsOutput?.[metricId];
+          const suppressGazeWarning = metricId === 'gaze' && eyeClosedSustained > 0;
 
           return (
             <MetricIndicator
               key={metricId}
               icon={config.icon}
               label={config.label}
-              isWarning={config.getWarningState(metricData)}
+              isWarning={suppressGazeWarning ? false : config.getWarningState(metricData)}
               fillRatio={config.getFillRatio?.(metricData)}
               isDisabled={isDisabled}
               isSelected={selectedMetric === metricId}

--- a/mobile/services/alerts/alert-config.ts
+++ b/mobile/services/alerts/alert-config.ts
@@ -67,7 +67,13 @@ export const ALERT_CONFIGS: AlertConfig[] = [
     message: 'Keep your eyes on the road.',
     priority: AlertPriority.MEDIUM,
     cooldownMs: 15000,
-    condition: (m: MetricsOutput) => !!getMetric(m, 'gaze')?.gaze_alert,
+    condition: (m: MetricsOutput) => {
+      const eyeClosure = getMetric(m, 'eye_closure');
+      if (eyeClosure?.eye_closed_sustained) {
+        return false;
+      }
+      return !!getMetric(m, 'gaze')?.gaze_alert;
+    },
   },
   {
     id: 'phone_usage',


### PR DESCRIPTION
## Describe your changes

Updated backend GazeMetric to reset and suppress gaze alerts if eyes are detected as closed based on EAR threshold. Modified mobile metrics display and alert config to prevent gaze warnings and alerts when eyes are closed, improving alert accuracy and user experience.

Fixes #65 
